### PR TITLE
#39 DatabaseContext declarations in repositories should use 'var'

### DIFF
--- a/API/MyMoney.API.DataAccess/Authentication/UserRepository.cs
+++ b/API/MyMoney.API.DataAccess/Authentication/UserRepository.cs
@@ -41,7 +41,7 @@
         /// </returns>
         public async Task<UserDataModel> GetUser(string email, string password)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var result = await context.Users.AsNoTracking().FirstOrDefaultAsync(x => x.EmailAddress == email);
 
@@ -71,7 +71,7 @@
         /// </exception>
         public async Task<Guid> GetUserIdByEmail(string username)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var result =
                 await context.Users.AsNoTracking()
@@ -97,7 +97,7 @@
         /// </returns>
         public async Task<UserDataModel> RegisterUser(UserDataModel model)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 model.Id = Guid.NewGuid();
                 model.CreationTime = DateTime.Now;

--- a/API/MyMoney.API.DataAccess/Common/CategoryRepository.cs
+++ b/API/MyMoney.API.DataAccess/Common/CategoryRepository.cs
@@ -37,7 +37,7 @@
         /// </returns>
         public async Task<CategoryDataModel> GetOrAdd(CategoryDataModel category)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 if (await Exists(category.Name))
                 {
@@ -55,7 +55,7 @@
         /// <returns>The newly added category.</returns>
         private async Task<CategoryDataModel> AddCategory(CategoryDataModel category)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 category.Id = Guid.NewGuid();
                 category.CreationTime = DateTime.Now;
@@ -75,7 +75,7 @@
         /// <returns>If it exists, true. Otherwise, false.</returns>
         private async Task<bool> Exists(string name)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 if (await context.Categories.CountAsync() > 0)
                 {
@@ -95,7 +95,7 @@
         /// </returns>
         private async Task<CategoryDataModel> GetCategory(string name)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 return await context.Categories.AsNoTracking().FirstOrDefaultAsync(x => x.Name == name);
             }

--- a/API/MyMoney.API.DataAccess/Saving/GoalRepository.cs
+++ b/API/MyMoney.API.DataAccess/Saving/GoalRepository.cs
@@ -40,7 +40,7 @@
         /// </returns>
         public async Task<GoalDataModel> AddGoal(GoalDataModel model)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 model.Id = Guid.NewGuid();
 
@@ -65,7 +65,7 @@
         /// </exception>
         public async Task<bool> DeleteGoal(Guid goalId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var toDelete = await context.Goals.FirstOrDefaultAsync(x => x.Id.Equals(goalId));
 
@@ -94,7 +94,7 @@
         /// </exception>
         public async Task<GoalDataModel> EditGoal(GoalDataModel model)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var toEdit = await GetGoal(model.Id);
 
@@ -127,7 +127,7 @@
         /// </exception>
         public async Task<GoalDataModel> GetGoal(Guid goalId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var goal = await context.Goals.AsNoTracking().FirstOrDefaultAsync(x => x.Id.Equals(goalId));
 
@@ -149,7 +149,7 @@
         /// </returns>
         public async Task<IList<GoalDataModel>> GetGoalsForUser(Guid userId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 return await context.Goals.AsNoTracking().Where(x => x.UserId.Equals(userId)).ToListAsync();
             }

--- a/API/MyMoney.API.DataAccess/Spending/BillRepository.cs
+++ b/API/MyMoney.API.DataAccess/Spending/BillRepository.cs
@@ -68,7 +68,7 @@
         /// </returns>
         public async Task<BillDataModel> AddBill(BillDataModel dataModel)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 dataModel.Id = Guid.NewGuid();
 
@@ -93,7 +93,7 @@
         /// <returns>If successful, true. Otherwise, false.</returns>
         public async Task<bool> DeleteBill(Guid billId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var toDelete = await GetBill(billId);
 
@@ -118,7 +118,7 @@
         /// <returns>The updated bill data model.</returns>
         public async Task<BillDataModel> EditBill(BillDataModel bill)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var toEdit = await GetBill(bill.Id);
 
@@ -155,7 +155,7 @@
         /// </exception>
         public async Task<BillDataModel> GetBill(Guid billId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var bill =
                 await context.Bills.Include(x => x.Category)
@@ -180,7 +180,7 @@
         /// </returns>
         public async Task<IList<BillDataModel>> GetBillsForUser(Guid userId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 return
                 await context.Bills.Include(x => x.Category)

--- a/API/MyMoney.API.DataAccess/Spending/ExpenditureRepository.cs
+++ b/API/MyMoney.API.DataAccess/Spending/ExpenditureRepository.cs
@@ -69,7 +69,7 @@
         /// </returns>
         public async Task<ExpenditureDataModel> AddExpenditure(ExpenditureDataModel dataModel)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 dataModel.Id = Guid.NewGuid();
 
@@ -94,7 +94,7 @@
         /// <returns>If successful, true. Otherwise, false.</returns>
         public async Task<bool> DeleteExpenditure(Guid expenditureId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var toDelete = await GetExpenditure(expenditureId);
 
@@ -119,7 +119,7 @@
         /// <returns>The updated expenditure data model.</returns>
         public async Task<ExpenditureDataModel> EditExpenditure(ExpenditureDataModel expenditure)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 var toEdit = await GetExpenditure(expenditure.Id);
 
@@ -153,7 +153,7 @@
         /// </returns>
         public async Task<ExpenditureDataModel> GetExpenditure(Guid expenditureId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 return
                 await context.Expenditures.Include(x => x.Category)
@@ -171,7 +171,7 @@
         /// </returns>
         public async Task<IList<ExpenditureDataModel>> GetExpenditureForUser(Guid userId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 return
                 await context.Expenditures.Include(x => x.Category)
@@ -190,7 +190,7 @@
         /// </returns>
         public async Task<IEnumerable<ExpenditureDataModel>> GetExpenditureForUserForMonth(Guid userId)
         {
-            using (DatabaseContext context = new DatabaseContext())
+            using (var context = new DatabaseContext())
             {
                 return
                 await context.Expenditures.Include(x => x.Category)


### PR DESCRIPTION
The using statements/DatabaseContext declarations on repos now use var rather than being strongly typed.