### PR TITLE
#33 Remove sensitive information from exported data.

### DIFF
--- a/Models/MyMoney.Proxies/Common/CategoryProxy.cs
+++ b/Models/MyMoney.Proxies/Common/CategoryProxy.cs
@@ -30,5 +30,16 @@
         public string Name { get; set; }
 
         #endregion
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 }

--- a/Shared/MyMoney.Helpers/Export/Csv/CsvGenerator.cs
+++ b/Shared/MyMoney.Helpers/Export/Csv/CsvGenerator.cs
@@ -1,0 +1,137 @@
+﻿namespace MyMoney.Helpers.Export.Csv
+{
+    #region Usings
+
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    #endregion
+
+    /// <summary>
+    ///     The <see cref="CsvGenerator" /> class is used for generating CSV (comma separated value) representations of
+    ///     objects.
+    /// </summary>
+    public class CsvGenerator
+    {
+        #region Constructor
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CsvGenerator" /> class.
+        /// </summary>
+        public CsvGenerator()
+        {
+            Headers = new List<string>();
+            Rows = new List<CsvRow>();
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        ///     Gets or sets the headers.
+        /// </summary>
+        /// <value>
+        ///     The headers.
+        /// </value>
+        private IList<string> Headers { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the rows.
+        /// </summary>
+        /// <value>
+        ///     The rows.
+        /// </value>
+        private IList<CsvRow> Rows { get; set; }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Adds a header.
+        /// </summary>
+        /// <param name="header">The header.</param>
+        /// <returns>This instance, for function chaining.</returns>
+        public CsvGenerator AddHeader(string header)
+        {
+            Headers.Add(header);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds multiple headers.
+        /// </summary>
+        /// <param name="headers">The headers.</param>
+        /// <returns>This instance, for function chaining.</returns>
+        public CsvGenerator AddHeaders(IEnumerable<string> headers)
+        {
+            foreach (var header in headers)
+            {
+                Headers.Add(header);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Creates a comma separated row.
+        /// </summary>
+        /// <param name="items">
+        /// The items.
+        /// </param>
+        /// <param name="ignoreHeaderCount">
+        /// If false, an <see cref="ArgumentNullException"/> is thrown when the number of items exceeds that of the number of headers.
+        /// </param>
+        /// <returns>
+        /// This instance, for function chaining.
+        /// </returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Exception thrown if the size of the row is greater than the number of headers.
+        /// </exception>
+        public CsvGenerator CreateRow(IList<string> items, bool ignoreHeaderCount = true)
+        {
+            if (items.Count > Headers.Count && !ignoreHeaderCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(items));
+            }
+
+            var row = new CsvRow(items);
+
+            Rows.Add(row);
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            var headerLine = string.Empty;
+            var body = string.Empty;
+
+            foreach (var header in Headers)
+            {
+                if (header == Headers.Last())
+                {
+                    headerLine += $"{header}\n";
+                    continue;
+                }
+
+                headerLine += $"{header},";
+            }
+
+            body = Rows.Aggregate(body, (current, row) => current + $"{row}\n");
+
+            return $"{headerLine}{body}";
+        }
+
+        #endregion
+    }
+}

--- a/Shared/MyMoney.Helpers/Export/Csv/CsvRow.cs
+++ b/Shared/MyMoney.Helpers/Export/Csv/CsvRow.cs
@@ -1,0 +1,64 @@
+﻿namespace MyMoney.Helpers.Export.Csv
+{
+    #region Usings
+
+    using System.Collections.Generic;
+    using System.Linq;
+
+    #endregion
+
+    /// <summary>
+    /// The <see cref="CsvRow"/> class is used to generate a comma separated row for use in a CSV file.
+    /// </summary>
+    public class CsvRow
+    {
+        #region Constructor
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CsvRow" /> class.
+        /// </summary>
+        /// <param name="items">The items.</param>
+        public CsvRow(IEnumerable<string> items)
+        {
+            Items = items.ToList();
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the items.
+        /// </summary>
+        /// <value>
+        /// The items.
+        /// </value>
+        private IList<string> Items { get; }
+
+        #endregion
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            var line = string.Empty;
+
+            foreach (var item in Items)
+            {
+                if (item == Items.Last())
+                {
+                    line += item;
+                    continue;
+                }
+
+                line += $"{item},";
+            }
+
+            return line;
+        }
+    }
+}

--- a/Shared/MyMoney.Helpers/Export/ExportHelper.cs
+++ b/Shared/MyMoney.Helpers/Export/ExportHelper.cs
@@ -1,0 +1,92 @@
+﻿namespace MyMoney.Helpers.Export
+{
+    #region Usings
+
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    using Csv;
+
+    using Interfaces;
+
+    using JetBrains.Annotations;
+
+    #endregion
+
+    /// <summary>
+    /// The <see cref="ExportHelper"/> class contains helper methods to convert objects into CSV, JSON and XML formats.
+    /// </summary>
+    /// <seealso cref="MyMoney.Helpers.Export.Interfaces.IExportHelper" />
+    [UsedImplicitly]
+    public class ExportHelper : IExportHelper
+    {
+        #region Methods
+
+        /// <summary>
+        /// Converts the given list of objects into CSV format.
+        /// </summary>
+        /// <typeparam name="T">The object type.</typeparam>
+        /// <param name="data">The data.</param>
+        /// <returns>The CSV representation of the given objects.</returns>
+        public string ToCsv<T>(IList<T> data)
+        {
+            var properties = GetCleanObjectProperties(data.First());
+            var propertyNames = properties.Select(x => x.Name).ToArray();
+
+            var generator = new CsvGenerator().AddHeaders(propertyNames);
+
+            foreach (var item in data)
+            {
+                var values = properties.Select(
+                    property => property.GetValue(item).ToString()).ToList();
+
+                generator.CreateRow(values, false);
+            }
+
+            return generator.ToString();
+        }
+
+        /// <summary>
+        /// Converts the given list of objects into XML format.
+        /// </summary>
+        /// <typeparam name="T">The object type.</typeparam>
+        /// <param name="data">The data.</param>
+        /// <returns>
+        /// The XML representation of the given objects.
+        /// </returns>
+        public string ToXml<T>(IEnumerable<T> data)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Converts the given list of objects into JSON format.
+        /// </summary>
+        /// <typeparam name="T">The object type.</typeparam>
+        /// <param name="data">The data.</param>
+        /// <returns>
+        /// The JSON representation of the given objects.
+        /// </returns>
+        public string ToJson<T>(IEnumerable<T> data)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the properties of the given object, excluding those that we do not want to be in the CSV files (such as ids etc.).
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <returns>The list of properties.</returns>
+        private static List<PropertyInfo> GetCleanObjectProperties(object item)
+        {
+            var type = item.GetType();
+            var properties = type.GetProperties();
+
+            return properties.Where(x => !x.Name.ToLowerInvariant().Contains("id")).ToList();
+        }
+
+        #endregion
+    }
+}

--- a/Shared/MyMoney.Helpers/Export/ExportHelper.cs
+++ b/Shared/MyMoney.Helpers/Export/ExportHelper.cs
@@ -13,6 +13,8 @@
 
     using JetBrains.Annotations;
 
+    using Xml;
+
     #endregion
 
     /// <summary>
@@ -56,9 +58,12 @@
         /// <returns>
         /// The XML representation of the given objects.
         /// </returns>
-        public string ToXml<T>(IEnumerable<T> data)
+        public string ToXml<T>(IList<T> data)
         {
-            throw new NotImplementedException();
+            var properties = GetCleanObjectProperties(data.First());
+            var propertyNames = properties.Select(x => x.Name).ToArray();
+
+            var generator = new XmlGenerator().AddNodeProperties(propertyNames).AddNodes(data);
         }
 
         /// <summary>

--- a/Shared/MyMoney.Helpers/Export/Interfaces/IExportHelper.cs
+++ b/Shared/MyMoney.Helpers/Export/Interfaces/IExportHelper.cs
@@ -1,0 +1,34 @@
+﻿namespace MyMoney.Helpers.Export.Interfaces
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The interface for the <see cref="ExportHelper"/> class.
+    /// </summary>
+    public interface IExportHelper
+    {
+        /// <summary>
+        /// Converts the given list of objects into CSV format.
+        /// </summary>
+        /// <typeparam name="T">The object type.</typeparam>
+        /// <param name="data">The data.</param>
+        /// <returns>The CSV representation of the given objects.</returns>
+        string ToCsv<T>(IList<T> data);
+
+        /// <summary>
+        /// Converts the given list of objects into XML format.
+        /// </summary>
+        /// <typeparam name="T">The object type.</typeparam>
+        /// <param name="data">The data.</param>
+        /// <returns>The XML representation of the given objects.</returns>
+        string ToXml<T>(IEnumerable<T> data);
+
+        /// <summary>
+        /// Converts the given list of objects into JSON format.
+        /// </summary>
+        /// <typeparam name="T">The object type.</typeparam>
+        /// <param name="data">The data.</param>
+        /// <returns>The JSON representation of the given objects.</returns>
+        string ToJson<T>(IEnumerable<T> data);
+    }
+}

--- a/Shared/MyMoney.Helpers/Export/Interfaces/IExportHelper.cs
+++ b/Shared/MyMoney.Helpers/Export/Interfaces/IExportHelper.cs
@@ -21,7 +21,7 @@
         /// <typeparam name="T">The object type.</typeparam>
         /// <param name="data">The data.</param>
         /// <returns>The XML representation of the given objects.</returns>
-        string ToXml<T>(IEnumerable<T> data);
+        string ToXml<T>(IList<T> data);
 
         /// <summary>
         /// Converts the given list of objects into JSON format.

--- a/Shared/MyMoney.Helpers/Export/Interfaces/IExportHelper.cs
+++ b/Shared/MyMoney.Helpers/Export/Interfaces/IExportHelper.cs
@@ -29,6 +29,6 @@
         /// <typeparam name="T">The object type.</typeparam>
         /// <param name="data">The data.</param>
         /// <returns>The JSON representation of the given objects.</returns>
-        string ToJson<T>(IEnumerable<T> data);
+        string ToJson<T>(IList<T> data);
     }
 }

--- a/Shared/MyMoney.Helpers/Export/Json/JsonGenerator.cs
+++ b/Shared/MyMoney.Helpers/Export/Json/JsonGenerator.cs
@@ -1,0 +1,66 @@
+﻿namespace MyMoney.Helpers.Export.Json
+{
+    using System.Collections.Generic;
+
+    public class JsonGenerator
+    {
+        private const string NodeFormat = "{{\n{0}\n}},\n";
+
+        private const string PropertyFormat = "\t{0}: {1},\n";
+
+        private const string BodyFormat = "{{[{0}]}}";
+
+        private readonly IList<object> nodes;
+
+        private readonly IList<string> nodeProperties;
+
+        public JsonGenerator()
+        {
+            nodes = new List<object>();
+            nodeProperties = new List<string>();
+        }
+
+        public JsonGenerator AddNodes<T>(IEnumerable<T> data)
+        {
+            foreach (var node in data)
+            {
+                nodes.Add(node);
+            }
+
+            return this;
+        }
+
+        public JsonGenerator AddNodeProperties(IList<string> properties)
+        {
+            foreach (var prop in properties)
+            {
+                nodeProperties.Add(prop);
+            }
+
+            return this;
+        }
+
+        public override string ToString()
+        {
+            var nodesString = string.Empty;
+
+            foreach (var item in nodes)
+            {
+                var properties = string.Empty;
+
+                foreach (var prop in nodeProperties)
+                {
+                    var value = item.GetType().GetProperty(prop)?.GetValue(item);
+
+                    properties += string.Format(PropertyFormat, prop, value);
+                }
+
+                var node = string.Format(NodeFormat, properties);
+
+                nodesString += node;
+            }
+
+            return string.Format(BodyFormat, nodesString);
+        }
+    }
+}

--- a/Shared/MyMoney.Helpers/Export/Json/JsonGenerator.cs
+++ b/Shared/MyMoney.Helpers/Export/Json/JsonGenerator.cs
@@ -2,24 +2,51 @@
 {
     using System.Collections.Generic;
 
+    /// <summary>
+    /// The <see cref="JsonGenerator"/> class converts objects into a JSON file format.
+    /// </summary>
     public class JsonGenerator
     {
+        /// <summary>
+        /// The node format
+        /// </summary>
         private const string NodeFormat = "{{\n{0}\n}},\n";
 
-        private const string PropertyFormat = "\t{0}: {1},\n";
+        /// <summary>
+        /// The property format
+        /// </summary>
+        private const string PropertyFormat = "\t{0}: \"{1}\",\n";
 
-        private const string BodyFormat = "{{[{0}]}}";
+        /// <summary>
+        /// The body format
+        /// </summary>
+        private const string BodyFormat = "{{data: [{0}]}}";
 
+        /// <summary>
+        /// The nodes
+        /// </summary>
         private readonly IList<object> nodes;
 
+        /// <summary>
+        /// The node properties
+        /// </summary>
         private readonly IList<string> nodeProperties;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonGenerator"/> class.
+        /// </summary>
         public JsonGenerator()
         {
             nodes = new List<object>();
             nodeProperties = new List<string>();
         }
 
+        /// <summary>
+        /// Adds the nodes.
+        /// </summary>
+        /// <typeparam name="T">The type of object.</typeparam>
+        /// <param name="data">The data.</param>
+        /// <returns>This instance, for function chaining.</returns>
         public JsonGenerator AddNodes<T>(IEnumerable<T> data)
         {
             foreach (var node in data)
@@ -30,7 +57,12 @@
             return this;
         }
 
-        public JsonGenerator AddNodeProperties(IList<string> properties)
+        /// <summary>
+        /// Adds the node properties.
+        /// </summary>
+        /// <param name="properties">The properties.</param>
+        /// <returns>This instance, for function chaining.</returns>
+        public JsonGenerator AddNodeProperties(IEnumerable<string> properties)
         {
             foreach (var prop in properties)
             {
@@ -40,6 +72,12 @@
             return this;
         }
 
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
         public override string ToString()
         {
             var nodesString = string.Empty;

--- a/Shared/MyMoney.Helpers/Export/Xml/XmlGenerator.cs
+++ b/Shared/MyMoney.Helpers/Export/Xml/XmlGenerator.cs
@@ -1,0 +1,126 @@
+﻿namespace MyMoney.Helpers.Export.Xml
+{
+    #region Usings
+
+    using System.Collections.Generic;
+    using System.Linq;
+
+    #endregion
+
+    /// <summary>
+    ///     The <see cref="XmlGenerator" /> class converts lists of objects into XML format.
+    /// </summary>
+    public class XmlGenerator
+    {
+        /// <summary>
+        ///     The attribute format
+        /// </summary>
+        private const string AttributeFormat = "{0}=\"{1}\" ";
+
+        /// <summary>
+        ///     The node format
+        /// </summary>
+        private const string NodeFormat = "\n\t<item {0} />";
+
+        /// <summary>
+        ///     The root format
+        /// </summary>
+        private const string RootFormat = "<root>{0}</root>";
+
+        #region Fields
+
+        /// <summary>
+        ///     The nodes
+        /// </summary>
+        private readonly IList<object> nodes;
+
+        /// <summary>
+        ///     The property names
+        /// </summary>
+        private readonly IList<string> propertyNames;
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="XmlGenerator" /> class.
+        /// </summary>
+        public XmlGenerator()
+        {
+            propertyNames = new List<string>();
+            nodes = new List<object>();
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        ///     Adds the node properties.
+        /// </summary>
+        /// <param name="props">The props.</param>
+        /// <returns>This instance, for function chaining.</returns>
+        public XmlGenerator AddNodeProperties(IList<string> props)
+        {
+            foreach (var prop in props)
+            {
+                propertyNames.Add(prop);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Adds the nodes.
+        /// </summary>
+        /// <typeparam name="T">The node type.</typeparam>
+        /// <param name="items">The items.</param>
+        /// <returns>This instance, for function chaining.</returns>
+        public XmlGenerator AddNodes<T>(IEnumerable<T> items)
+        {
+            foreach (var item in items)
+            {
+                nodes.Add(item);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            var nodeLines = string.Empty;
+
+            foreach (var node in nodes)
+            {
+                var nodeAttributes = new Dictionary<string, object>();
+
+                foreach (var propertyName in propertyNames)
+                {
+                    var value = node.GetType().GetProperty(propertyName)?.GetValue(node);
+
+                    nodeAttributes.Add(propertyName, value);
+                }
+
+                var attributeLine = nodeAttributes.Aggregate(
+                    string.Empty,
+                    (current, nodeAttribute) => current + string.Format(
+                                                    AttributeFormat,
+                                                    nodeAttribute.Key,
+                                                    nodeAttribute.Value));
+
+                nodeLines += string.Format(NodeFormat, attributeLine);
+            }
+
+            return string.Format(RootFormat, nodeLines);
+        }
+
+        #endregion
+    }
+}

--- a/Shared/MyMoney.Helpers/Export/Xml/XmlGenerator.cs
+++ b/Shared/MyMoney.Helpers/Export/Xml/XmlGenerator.cs
@@ -20,7 +20,7 @@
         /// <summary>
         ///     The node format
         /// </summary>
-        private const string NodeFormat = "\n\t<item {0} />";
+        private const string NodeFormat = "\n\t<item {0} />\n";
 
         /// <summary>
         ///     The root format

--- a/Shared/MyMoney.Helpers/MyMoney.Helpers.csproj
+++ b/Shared/MyMoney.Helpers/MyMoney.Helpers.csproj
@@ -92,6 +92,10 @@
     <Compile Include="Benchmarking\Benchmark.cs" />
     <Compile Include="Benchmarking\BenchmarkHelper.cs" />
     <Compile Include="Error\Interfaces\IErrorHelper.cs" />
+    <Compile Include="Export\Csv\CsvGenerator.cs" />
+    <Compile Include="Export\Csv\CsvRow.cs" />
+    <Compile Include="Export\ExportHelper.cs" />
+    <Compile Include="Export\Interfaces\IExportHelper.cs" />
     <Compile Include="Logging\Interfaces\ILogHelper.cs" />
     <Compile Include="Logging\LogHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Shared/MyMoney.Helpers/MyMoney.Helpers.csproj
+++ b/Shared/MyMoney.Helpers/MyMoney.Helpers.csproj
@@ -96,6 +96,8 @@
     <Compile Include="Export\Csv\CsvRow.cs" />
     <Compile Include="Export\ExportHelper.cs" />
     <Compile Include="Export\Interfaces\IExportHelper.cs" />
+    <Compile Include="Export\Json\JsonGenerator.cs" />
+    <Compile Include="Export\Xml\XmlGenerator.cs" />
     <Compile Include="Logging\Interfaces\ILogHelper.cs" />
     <Compile Include="Logging\LogHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Web/MyMoney.Web.Assemblers.Tests/MyMoney.Web.Assemblers.Tests.csproj
+++ b/Web/MyMoney.Web.Assemblers.Tests/MyMoney.Web.Assemblers.Tests.csproj
@@ -61,6 +61,9 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
+    <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
@@ -114,6 +117,10 @@
     <ProjectReference Include="..\..\Shared\MyMoney.DTO\MyMoney.DTO.csproj">
       <Project>{DB1B76A1-FF34-49A1-A219-3C14481CA713}</Project>
       <Name>MyMoney.DTO</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Shared\MyMoney.Helpers\MyMoney.Helpers.csproj">
+      <Project>{0BA52AA7-2122-4690-9216-BEC476EA81ED}</Project>
+      <Name>MyMoney.Helpers</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Shared\MyMoney.Wrappers\MyMoney.Wrappers.csproj">
       <Project>{D944DAEC-CA72-48DB-8CFE-A372A60EFB4A}</Project>

--- a/Web/MyMoney.Web.Assemblers.Tests/Spending/BillAssemblerTests.cs
+++ b/Web/MyMoney.Web.Assemblers.Tests/Spending/BillAssemblerTests.cs
@@ -12,6 +12,8 @@
     using DTO.Request.Spending.Bill;
     using DTO.Response.Spending.Bill;
 
+    using Helpers.Export;
+
     using NUnit.Framework;
 
     using Proxies.Common;
@@ -20,6 +22,9 @@
     using ViewModels.Common;
     using ViewModels.Enum;
     using ViewModels.Spending.Bill;
+    using MyMoney.Helpers.Export.Interfaces;
+
+    using NSubstitute;
 
     #endregion
 
@@ -48,6 +53,8 @@
         private Guid validUserId;
 
         private string validUsername;
+
+        private IExportHelper exportHelper;
 
         #endregion
 
@@ -355,7 +362,13 @@
         [SetUp]
         public void SetUp()
         {
-            assembler = new BillAssembler();
+            exportHelper = Substitute.For<IExportHelper>();
+
+            exportHelper.ToCsv(new List<string>()).ReturnsForAnyArgs(string.Empty);
+            exportHelper.ToCsv(new List<string>()).ReturnsForAnyArgs(string.Empty);
+            exportHelper.ToCsv(new List<string>()).ReturnsForAnyArgs(string.Empty);
+
+            assembler = new BillAssembler(exportHelper);
             validUsername = "TEST";
             validBillId = Guid.NewGuid();
             validUserId = Guid.NewGuid();

--- a/Web/MyMoney.Web.Assemblers.Tests/Spending/ExpenditureAssemblerTests.cs
+++ b/Web/MyMoney.Web.Assemblers.Tests/Spending/ExpenditureAssemblerTests.cs
@@ -11,6 +11,10 @@
     using DTO.Request.Spending.Expenditure;
     using DTO.Response.Spending.Expenditure;
 
+    using Helpers.Export.Interfaces;
+
+    using NSubstitute;
+
     using NUnit.Framework;
 
     using Proxies.Common;
@@ -367,10 +371,18 @@
             Assert.AreEqual(test.Expenditure.Count, 1);
         }
 
+        private IExportHelper exportHelper;
+
         [SetUp]
         public void SetUp()
         {
-            assembler = new ExpenditureAssembler();
+            exportHelper = Substitute.For<IExportHelper>();
+
+            exportHelper.ToCsv(new List<string>()).ReturnsForAnyArgs(string.Empty);
+            exportHelper.ToJson(new List<string>()).ReturnsForAnyArgs(string.Empty);
+            exportHelper.ToXml(new List<string>()).ReturnsForAnyArgs(string.Empty);
+
+            assembler = new ExpenditureAssembler(exportHelper);
             validUsername = "TEST";
             validExpenditureId = Guid.NewGuid();
             validUserId = Guid.NewGuid();

--- a/Web/MyMoney.Web.Assemblers.Tests/packages.config
+++ b/Web/MyMoney.Web.Assemblers.Tests/packages.config
@@ -4,5 +4,6 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
+  <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
 </packages>

--- a/Web/MyMoney.Web.Assemblers/BaseAssembler.cs
+++ b/Web/MyMoney.Web.Assemblers/BaseAssembler.cs
@@ -1,0 +1,49 @@
+﻿namespace MyMoney.Web.Assemblers
+{
+    #region Usings
+
+    using System;
+
+    using Helpers.Export.Interfaces;
+
+    #endregion
+
+    /// <summary>
+    /// The <see cref="BaseAssembler"/> class is the parent class for all assemblers in the web application.
+    /// </summary>
+    public class BaseAssembler
+    {
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseAssembler"/> class.
+        /// </summary>
+        /// <param name="exportHelper">The export helper.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Exception thrown if the export helper is null.
+        /// </exception>
+        protected BaseAssembler(IExportHelper exportHelper)
+        {
+            if (exportHelper == null)
+            {
+                throw new ArgumentNullException(nameof(exportHelper));
+            }
+
+            ExportHelper = exportHelper;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the export helper.
+        /// </summary>
+        /// <value>
+        /// The export helper.
+        /// </value>
+        protected IExportHelper ExportHelper { get; }
+
+        #endregion
+    }
+}

--- a/Web/MyMoney.Web.Assemblers/MyMoney.Web.Assemblers.csproj
+++ b/Web/MyMoney.Web.Assemblers/MyMoney.Web.Assemblers.csproj
@@ -83,6 +83,7 @@
   <ItemGroup>
     <Compile Include="Authentication\Interfaces\IUserAssembler.cs" />
     <Compile Include="Authentication\UserAssembler.cs" />
+    <Compile Include="BaseAssembler.cs" />
     <Compile Include="Chart\ChartAssembler.cs" />
     <Compile Include="Chart\Interfaces\IChartAssembler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -105,6 +106,10 @@
     <ProjectReference Include="..\..\Shared\MyMoney.DTO\MyMoney.DTO.csproj">
       <Project>{DB1B76A1-FF34-49A1-A219-3C14481CA713}</Project>
       <Name>MyMoney.DTO</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Shared\MyMoney.Helpers\MyMoney.Helpers.csproj">
+      <Project>{0BA52AA7-2122-4690-9216-BEC476EA81ED}</Project>
+      <Name>MyMoney.Helpers</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Web/MyMoney.Web.Assemblers/Spending/BillAssembler.cs
+++ b/Web/MyMoney.Web.Assemblers/Spending/BillAssembler.cs
@@ -186,10 +186,10 @@
                     retVal.FileData = ExportHelper.ToCsv(apiResponseBills);
                     break;
                 case ExportType.Xml:
-                    retVal.FileData = apiResponseBills.ToXml();
+                    retVal.FileData = ExportHelper.ToXml(apiResponseBills);
                     break;
                 case ExportType.Json:
-                    retVal.FileData = apiResponseBills.ToJson();
+                    retVal.FileData = ExportHelper.ToJson(apiResponseBills);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(exportType), exportType, null);

--- a/Web/MyMoney.Web.Assemblers/Spending/BillAssembler.cs
+++ b/Web/MyMoney.Web.Assemblers/Spending/BillAssembler.cs
@@ -10,6 +10,8 @@
     using DTO.Request.Spending.Bill;
     using DTO.Response.Spending.Bill;
 
+    using Helpers.Export.Interfaces;
+
     using Interfaces;
 
     using JetBrains.Annotations;
@@ -30,8 +32,17 @@
     /// </summary>
     /// <seealso cref="MyMoney.Web.Assemblers.Spending.Interfaces.IBillAssembler" />
     [UsedImplicitly]
-    public class BillAssembler : IBillAssembler
+    public class BillAssembler : BaseAssembler, IBillAssembler
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BillAssembler"/> class.
+        /// </summary>
+        /// <param name="exportHelper">The export helper.</param>
+        public BillAssembler(IExportHelper exportHelper)
+            : base(exportHelper)
+        {            
+        }
+
         #region Methods
 
         /// <summary>
@@ -172,7 +183,7 @@
             switch (exportType)
             {
                 case ExportType.Csv:
-                    retVal.FileData = apiResponseBills.ToCsv();
+                    retVal.FileData = ExportHelper.ToCsv(apiResponseBills);
                     break;
                 case ExportType.Xml:
                     retVal.FileData = apiResponseBills.ToXml();

--- a/Web/MyMoney.Web.Assemblers/Spending/ExpenditureAssembler.cs
+++ b/Web/MyMoney.Web.Assemblers/Spending/ExpenditureAssembler.cs
@@ -10,6 +10,8 @@
     using DTO.Request.Spending.Expenditure;
     using DTO.Response.Spending.Expenditure;
 
+    using Helpers.Export.Interfaces;
+
     using Interfaces;
 
     using JetBrains.Annotations;
@@ -30,8 +32,17 @@
     /// </summary>
     /// <seealso cref="MyMoney.Web.Assemblers.Spending.Interfaces.IExpenditureAssembler" />
     [UsedImplicitly]
-    public class ExpenditureAssembler : IExpenditureAssembler
+    public class ExpenditureAssembler : BaseAssembler, IExpenditureAssembler
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpenditureAssembler"/> class.
+        /// </summary>
+        /// <param name="exportHelper">The export helper.</param>
+        public ExpenditureAssembler(IExportHelper exportHelper)
+            : base(exportHelper)
+        {           
+        }
+
         #region Methods
 
         /// <summary>
@@ -195,13 +206,13 @@
             switch (exportType)
             {
                 case ExportType.Csv:
-                    retVal.FileData = apiResponseExpenditures.ToCsv();
+                    retVal.FileData = ExportHelper.ToCsv(apiResponseExpenditures);
                     break;
                 case ExportType.Xml:
-                    retVal.FileData = apiResponseExpenditures.ToXml();
+                    retVal.FileData = ExportHelper.ToXml(apiResponseExpenditures);
                     break;
                 case ExportType.Json:
-                    retVal.FileData = apiResponseExpenditures.ToJson();
+                    retVal.FileData = ExportHelper.ToJson(apiResponseExpenditures);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(exportType), exportType, null);

--- a/Web/MyMoney.Web.DependencyInjection/Installers/AssemblersInstaller.cs
+++ b/Web/MyMoney.Web.DependencyInjection/Installers/AssemblersInstaller.cs
@@ -15,6 +15,9 @@
     using Castle.MicroKernel.SubSystems.Configuration;
     using Castle.Windsor;
 
+    using Helpers.Export;
+    using Helpers.Export.Interfaces;
+
     #endregion
 
     /// <summary>
@@ -34,7 +37,13 @@
         {
             container.Register(Component.For<IGoalAssembler>().ImplementedBy<GoalAssembler>().LifestylePerWebRequest());
             container.Register(Component.For<IUserAssembler>().ImplementedBy<UserAssembler>().LifestylePerWebRequest());
-            container.Register(Component.For<IBillAssembler>().ImplementedBy<BillAssembler>().LifestylePerWebRequest());
+
+            container.Register(
+                Component.For<IBillAssembler>()
+                    .ImplementedBy<BillAssembler>()
+                    .LifestylePerWebRequest()
+                    .DependsOn(Dependency.OnComponent<IExportHelper, ExportHelper>()));
+
             container.Register(
                 Component.For<IChartAssembler>().ImplementedBy<ChartAssembler>().LifestylePerWebRequest());
             container.Register(

--- a/Web/MyMoney.Web.DependencyInjection/Installers/AssemblersInstaller.cs
+++ b/Web/MyMoney.Web.DependencyInjection/Installers/AssemblersInstaller.cs
@@ -36,6 +36,7 @@
         public void Install(IWindsorContainer container, IConfigurationStore store)
         {
             container.Register(Component.For<IGoalAssembler>().ImplementedBy<GoalAssembler>().LifestylePerWebRequest());
+
             container.Register(Component.For<IUserAssembler>().ImplementedBy<UserAssembler>().LifestylePerWebRequest());
 
             container.Register(
@@ -46,8 +47,12 @@
 
             container.Register(
                 Component.For<IChartAssembler>().ImplementedBy<ChartAssembler>().LifestylePerWebRequest());
+
             container.Register(
-                Component.For<IExpenditureAssembler>().ImplementedBy<ExpenditureAssembler>().LifestylePerWebRequest());
+                Component.For<IExpenditureAssembler>()
+                    .ImplementedBy<ExpenditureAssembler>()
+                    .LifestylePerWebRequest()
+                    .DependsOn(Dependency.OnComponent<IExportHelper, ExportHelper>()));
         }
 
         #endregion

--- a/Web/MyMoney.Web.DependencyInjection/Installers/HelperInstaller.cs
+++ b/Web/MyMoney.Web.DependencyInjection/Installers/HelperInstaller.cs
@@ -10,6 +10,8 @@
     using Helpers.Benchmarking.Interfaces;
     using Helpers.Error;
     using Helpers.Error.Interfaces;
+    using Helpers.Export;
+    using Helpers.Export.Interfaces;
     using Helpers.Logging;
     using Helpers.Logging.Interfaces;
     using Helpers.Views;
@@ -44,6 +46,8 @@
 
             container.Register(
                 Component.For<IBenchmarkHelper>().ImplementedBy<BenchmarkHelper>().LifestylePerWebRequest());
+
+            container.Register(Component.For<IExportHelper>().ImplementedBy<ExportHelper>().LifestylePerWebRequest());
         }
 
         #endregion


### PR DESCRIPTION
Implemented our own generators for CSV, XML and JSON formatting which are used by the IExportHelper. There is now a method these use called "GetCleanedPropertyNames" which can be modified accordingly to remove a list of strings such as "id" etc.

Added full documentation and updated tests.