### PR TITLE
#65 Refactor API Orchestrators to use base Orchestrate<TRequest, TResponse>() method.

### DIFF
--- a/API/MyMoney.API.Orchestrators.Tests/Saving/GoalOrchestratorTests.cs
+++ b/API/MyMoney.API.Orchestrators.Tests/Saving/GoalOrchestratorTests.cs
@@ -257,7 +257,7 @@
         [Test]
         public void AddGoal_ValidParams_ReturnsResponse()
         {
-            var test = orchestrator.AddGoal(validAddGoalRequest, "TEST").Result;
+            var test = orchestrator.AddGoal(validAddGoalRequest).Result;
 
             Assert.IsNotNull(test);
             Assert.IsInstanceOf<AddGoalResponse>(test);
@@ -268,7 +268,7 @@
         [Test]
         public void AddGoal_ExceptionThrown_ReturnsErrorResponse()
         {
-            var test = orchestrator.AddGoal(invalidAddGoalRequest, "TEST").Result;
+            var test = orchestrator.AddGoal(invalidAddGoalRequest).Result;
 
             Assert.IsNotNull(test);
             Assert.IsInstanceOf<AddGoalResponse>(test);

--- a/API/MyMoney.API.Orchestrators.Tests/Spending/BillOrchestratorTests.cs
+++ b/API/MyMoney.API.Orchestrators.Tests/Spending/BillOrchestratorTests.cs
@@ -343,7 +343,7 @@
         [Test]
         public void AddBill_ValidParams_ReturnsResponse()
         {
-            var test = orchestrator.AddBill(validAddBillRequest, "TEST").Result;
+            var test = orchestrator.AddBill(validAddBillRequest).Result;
 
             Assert.IsNotNull(test);
             Assert.IsInstanceOf<AddBillResponse>(test);
@@ -354,7 +354,7 @@
         [Test]
         public void AddBill_ExceptionThrown_ReturnsErrorResponse()
         {
-            var test = orchestrator.AddBill(invalidAddBillRequest, "TEST").Result;
+            var test = orchestrator.AddBill(invalidAddBillRequest).Result;
 
             Assert.IsNotNull(test);
             Assert.IsInstanceOf<AddBillResponse>(test);

--- a/API/MyMoney.API.Orchestrators.Tests/Spending/ExpenditureOrchestratorTests.cs
+++ b/API/MyMoney.API.Orchestrators.Tests/Spending/ExpenditureOrchestratorTests.cs
@@ -335,7 +335,7 @@
         [Test]
         public void AddExpenditure_ValidParams_ReturnsResponse()
         {
-            var test = orchestrator.AddExpenditure(validAddExpenditureRequest, "TEST").Result;
+            var test = orchestrator.AddExpenditure(validAddExpenditureRequest).Result;
 
             Assert.IsNotNull(test);
             Assert.IsInstanceOf<AddExpenditureResponse>(test);
@@ -346,7 +346,7 @@
         [Test]
         public void AddExpenditure_ExceptionThrown_ReturnsErrorResponse()
         {
-            var test = orchestrator.AddExpenditure(invalidAddExpenditureRequest, "TEST").Result;
+            var test = orchestrator.AddExpenditure(invalidAddExpenditureRequest).Result;
 
             Assert.IsNotNull(test);
             Assert.IsInstanceOf<AddExpenditureResponse>(test);

--- a/API/MyMoney.API.Orchestrators/Authentication/UserOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Authentication/UserOrchestrator.cs
@@ -87,22 +87,12 @@
         /// </returns>
         public async Task<RegisterUserResponse> RegisterUser(RegisterUserRequest request)
         {
-            var response = new RegisterUserResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate{
                 var dataModel = assembler.NewUserDataModel(request);
                 var registerResult = await repository.RegisterUser(dataModel);
 
-                response = assembler.NewRegisterUserResponse(registerResult, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.EmailAddress, GetType(), "RegisterUser");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewRegisterUserResponse(registerResult, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -114,21 +104,11 @@
         /// </returns>
         public async Task<ValidateUserResponse> ValidateUser(ValidateUserRequest request)
         {
-            var response = new ValidateUserResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate{
                 var userDataModel = await repository.GetUser(request.EmailAddress, request.Password);
 
-                response = assembler.NewValidateUserResponse(userDataModel, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "ValidateUser");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewValidateUserResponse(userDataModel, request.RequestReference);
+            }, request);
         }
 
         #endregion

--- a/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
@@ -7,6 +7,7 @@
     using Helpers.Error.Interfaces;
 
     using DTO.Request;
+    using DTO.Response;
 
     using System.Threading.Tasks;
 

--- a/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
@@ -42,5 +42,35 @@
         protected IErrorHelper ErrorHelper { get; }
 
         #endregion
+
+        #region Methods 
+
+        ///     Orchestrates the specified method.
+        /// </summary>
+        /// <typeparam name="TRequest">The type of the request.</typeparam>
+        /// <typeparam name="TResponse">The type of the response.</typeparam>
+        /// <param name="method">The orchestrator method.</param>
+        /// <param name="request">The request.</param>
+        /// <returns>The response object.</returns>
+        protected async Task<TResponse> Orchestrate<TRequest, TResponse>(Func<TRequest, Task<TResponse>> method, TRequest request)
+            where TResponse : BaseResponse where TRequest : BaseRequest
+        {
+            var response = Activator.CreateInstance<TResponse>();
+
+            try
+            {
+                response = await method(request);
+            }
+            catch (Exception ex)
+            {
+                var err = errorHelper.Create(ex, request.Username, GetType(), "Orchestrate");
+
+                response.AddError(err);
+            }
+
+            return response;
+        }
+
+        #endregion
     }
 }

--- a/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
@@ -45,6 +45,11 @@
         ///     Gets the error helper.
         /// </summary>
         protected IErrorHelper ErrorHelper { get; }
+        
+        /// <summary>
+        ///     The name of the method that called the current one.
+        /// </summary>
+        public string CalledBy => new StackTrace().GetFrame(1).GetMethod().Name;
 
         #endregion
 
@@ -68,7 +73,7 @@
             }
             catch (Exception ex)
             {
-                var err = errorHelper.Create(ex, request.Username, GetType(), "Orchestrate");
+                var err = ErrorHelper.Create(ex, request.Username, GetType(), CalledBy);
 
                 response.AddError(err);
             }

--- a/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
@@ -10,6 +10,7 @@
     using DTO.Response;
 
     using System.Threading.Tasks;
+    using System.Diagnostics;
 
     #endregion
 

--- a/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
@@ -6,7 +6,7 @@
 
     using Helpers.Error.Interfaces;
 
-    using DTO.Requests;
+    using DTO.Request;
 
     using System.Threading.Tasks;
 

--- a/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
@@ -6,6 +6,10 @@
 
     using Helpers.Error.Interfaces;
 
+    using DTO;
+
+    using System.Threading.Tasks;
+
     #endregion
 
     /// <summary>

--- a/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/BaseOrchestrator.cs
@@ -6,7 +6,7 @@
 
     using Helpers.Error.Interfaces;
 
-    using DTO;
+    using DTO.Requests;
 
     using System.Threading.Tasks;
 

--- a/API/MyMoney.API.Orchestrators/Chart/ChartOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Chart/ChartOrchestrator.cs
@@ -140,22 +140,12 @@
         public async Task<GetBillCategoryChartDataResponse> GetBillCategoryChartData(
             GetBillCategoryChartDataRequest request)
         {
-            var response = new GetBillCategoryChartDataResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var bills = await billRepository.GetBillsForUser(request.UserId);
                 var data = billDataTransformer.GetBillCategoryChartData(bills);
 
-                response = assembler.NewGetBillCategoryChartDataResponse(data, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetBillCategoryChartData");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetBillCategoryChartDataResponse(data, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -167,22 +157,12 @@
         /// </returns>
         public async Task<GetBillPeriodChartDataResponse> GetBillPeriodChartData(GetBillPeriodChartDataRequest request)
         {
-            var response = new GetBillPeriodChartDataResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var bills = await billRepository.GetBillsForUser(request.UserId);
                 var data = billDataTransformer.GetBillPeriodChartData(bills);
 
-                response = assembler.NewGetBillPeriodChartDataResponse(data, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetBillCategoryChartData");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetBillPeriodChartDataResponse(data, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -193,22 +173,12 @@
         public async Task<GetExpenditureChartDataResponse> GetExpenditureChartData(
             GetExpenditureChartDataRequest request)
         {
-            var response = new GetExpenditureChartDataResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var expenditure = await expenditureRepository.GetExpenditureForUserForMonth(request.UserId);
                 var data = expenditureDataTransformer.GetRollingExpenditureSum(expenditure);
 
-                response = assembler.NewGetExpenditureChartDataResponse(data, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetExpenditureChartData");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetExpenditureChartDataResponse(data, request.RequestReference);
+            }, request);
         }
 
         #endregion

--- a/API/MyMoney.API.Orchestrators/Saving/GoalOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Saving/GoalOrchestrator.cs
@@ -107,7 +107,7 @@
         {
             return await Orchestrate(async delegate {
                 var dataModel = assembler.NewGoalDataModel(request.Goal);
-                var editedModel = await repository.Edit(dataModel);
+                var editedModel = await repository.EditGoal(dataModel);
 
                 return assembler.NewEditGoalResponse(editedModel, request.RequestReference);
             }, request);

--- a/API/MyMoney.API.Orchestrators/Saving/GoalOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Saving/GoalOrchestrator.cs
@@ -86,24 +86,14 @@
         /// <returns>
         ///     The response object.
         /// </returns>
-        public async Task<AddGoalResponse> AddGoal(AddGoalRequest request, string requestUsername)
+        public async Task<AddGoalResponse> AddGoal(AddGoalRequest request)
         {
-            var response = new AddGoalResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var dataModel = assembler.NewGoalDataModel(request.Goal);
                 var addedModel = await repository.AddGoal(dataModel);
 
-                response = assembler.NewAddGoalResponse(addedModel, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, requestUsername, GetType(), "AddGoal");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewAddGoalResponse(addedModel, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -115,48 +105,11 @@
         /// </returns>
         public async Task<DeleteGoalResponse> DeleteGoal(DeleteGoalRequest request)
         {
-            var response = new DeleteGoalResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var deleteSuccess = await repository.DeleteGoal(request.GoalId);
 
-                response = assembler.NewDeleteGoalResponse(deleteSuccess, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "DeleteGoal");
-                response.AddError(err);
-            }
-
-            return response;
-        }
-
-        /// <summary>
-        ///     Updates a goal within the database.
-        /// </summary>
-        /// <param name="request">The request.</param>
-        /// <returns>
-        ///     The response object.
-        /// </returns>
-        public async Task<EditGoalResponse> EditGoal(EditGoalRequest request)
-        {
-            var response = new EditGoalResponse();
-
-            try
-            {
-                var dataModel = assembler.NewGoalDataModel(request.Goal);
-                var updatedDataModel = await repository.EditGoal(dataModel);
-
-                response = assembler.NewEditGoalResponse(updatedDataModel, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "EditGoal");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewDeleteGoalResponse(deleteSuccess, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -168,21 +121,11 @@
         /// </returns>
         public async Task<GetGoalResponse> GetGoal(GetGoalRequest request)
         {
-            var response = new GetGoalResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var dataModel = await repository.GetGoal(request.GoalId);
 
-                response = assembler.NewGetGoalResponse(dataModel, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetGoal");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetGoalResponse(dataModel, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -194,20 +137,11 @@
         /// </returns>
         public async Task<GetGoalsForUserResponse> GetGoalsForUser(GetGoalsForUserRequest request)
         {
-            var response = new GetGoalsForUserResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var goals = await repository.GetGoalsForUser(request.UserId);
-                response = assembler.NewGetGoalsForUserResponse(goals, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetGoalsForUser");
-                response.AddError(err);
-            }
-
-            return response;
+                
+                return assembler.NewGetGoalsForUserResponse(goals, request.RequestReference);
+            }, request);
         }
 
         #endregion

--- a/API/MyMoney.API.Orchestrators/Saving/GoalOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Saving/GoalOrchestrator.cs
@@ -82,7 +82,6 @@
         ///     Adds a goal to the database.
         /// </summary>
         /// <param name="request">The request.</param>
-        /// <param name="requestUsername">The request username.</param>
         /// <returns>
         ///     The response object.
         /// </returns>
@@ -93,6 +92,24 @@
                 var addedModel = await repository.AddGoal(dataModel);
 
                 return assembler.NewAddGoalResponse(addedModel, request.RequestReference);
+            }, request);
+        }
+
+
+        /// <summary>
+        ///     Modifies a goal in the database.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>
+        ///     The response object.
+        /// </returns>
+        public async Task<EditGoalResponse> EditGoal(EditGoalRequest request)
+        {
+            return await Orchestrate(async delegate {
+                var dataModel = assembler.NewGoalDataModel(request.Goal);
+                var editedModel = await repository.Edit(dataModel);
+
+                return assembler.NewEditGoalResponse(editedModel, request.RequestReference);
             }, request);
         }
 

--- a/API/MyMoney.API.Orchestrators/Saving/Interfaces/IGoalOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Saving/Interfaces/IGoalOrchestrator.cs
@@ -20,9 +20,8 @@
         /// Adds a goal to the database.
         /// </summary>
         /// <param name="request">The request.</param>
-        /// <param name="requestUsername">The request username.</param>
         /// <returns>The response object.</returns>
-        Task<AddGoalResponse> AddGoal(AddGoalRequest request, string requestUsername);
+        Task<AddGoalResponse> AddGoal(AddGoalRequest request);
 
         /// <summary>
         /// Deletes a goal from the database.

--- a/API/MyMoney.API.Orchestrators/Spending/BillOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Spending/BillOrchestrator.cs
@@ -103,28 +103,17 @@
         ///     Adds a bill.
         /// </summary>
         /// <param name="request">The request.</param>
-        /// <param name="username">The username.</param>
         /// <returns>
         ///     The response object.
         /// </returns>
-        public async Task<AddBillResponse> AddBill(AddBillRequest request, string username)
+        public async Task<AddBillResponse> AddBill(AddBillRequest request)
         {
-            var response = new AddBillResponse();
+           return await Orchestrate(async delegate {
+               var dataModel = assembler.NewBillDataModel(request.Bill);
+               var bill = await repository.AddBill(dataModel);
 
-            try
-            {
-                var dataModel = assembler.NewBillDataModel(request.Bill);
-                var bills = await repository.AddBill(dataModel);
-
-                response = assembler.NewAddBillResponse(bills, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, username, GetType(), "AddBill");
-                response.AddError(err);
-            }
-
-            return response;
+               return assembler.NewAddBillResponse(bill, request.RequestReference);
+           }, request.Username);
         }
 
         /// <summary>
@@ -134,21 +123,11 @@
         /// <returns>The response object.</returns>
         public async Task<DeleteBillResponse> DeleteBill(DeleteBillRequest request)
         {
-            var response = new DeleteBillResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var success = await repository.DeleteBill(request.BillId);
 
-                response = assembler.NewDeleteBillResponse(success, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "DeleteBill");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewDeleteBillResponse(success, request.RequestReference);
+            }, username);
         }
 
         /// <summary>
@@ -158,23 +137,12 @@
         /// <returns>The response object.</returns>
         public async Task<EditBillResponse> EditBill(EditBillRequest request)
         {
-            var response = new EditBillResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var dataModel = assembler.NewBillDataModel(request.Bill);
-
                 var model = await repository.EditBill(dataModel);
 
-                response = assembler.NewEditBillResponse(model, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "EditBill");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewEditBillResponse(model, request.RequestReference);
+            }, request.Username);
         }
 
         /// <summary>
@@ -184,21 +152,11 @@
         /// <returns>The response object.</returns>
         public async Task<GetBillResponse> GetBill(GetBillRequest request)
         {
-            var response = new GetBillResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var bill = await repository.GetBill(request.BillId);
 
-                response = assembler.NewGetBillResponse(bill, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetBill");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetBillResponse(bill, request.RequestReference);
+            }, request.Username);
         }
 
         /// <summary>
@@ -208,21 +166,11 @@
         /// <returns>The response object.</returns>
         public async Task<GetBillsForUserResponse> GetBillsForUser(GetBillsForUserRequest request)
         {
-            var response = new GetBillsForUserResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var bills = await repository.GetBillsForUser(request.UserId);
 
-                response = assembler.NewGetBillsForUserResponse(bills, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetBillsForUser");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetBillsForUserResponse(bills, request.RequestReference);
+            }, request.Username);
         }
 
         /// <summary>
@@ -235,22 +183,12 @@
         public async Task<GetBillsForUserForMonthResponse> GetBillsForUserForMonth(
             GetBillsForUserForMonthRequest request)
         {
-            var response = new GetBillsForUserForMonthResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var bills = await repository.GetBillsForUser(request.UserId);
                 var data = dataTransformer.GetOutgoingBillsForMonth(request.MonthNumber, bills);
 
-                response = assembler.NewGetBillsForUserForMonthResponse(data, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetBillsForUserForMonth");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetBillsForUserForMonthResponse(data, request.RequestReference);
+            }, request.Username);
         }
 
         #endregion

--- a/API/MyMoney.API.Orchestrators/Spending/BillOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Spending/BillOrchestrator.cs
@@ -113,7 +113,7 @@
                var bill = await repository.AddBill(dataModel);
 
                return assembler.NewAddBillResponse(bill, request.RequestReference);
-           }, request.Username);
+           }, request);
         }
 
         /// <summary>
@@ -127,7 +127,7 @@
                 var success = await repository.DeleteBill(request.BillId);
 
                 return assembler.NewDeleteBillResponse(success, request.RequestReference);
-            }, username);
+            }, request);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@
                 var model = await repository.EditBill(dataModel);
 
                 return assembler.NewEditBillResponse(model, request.RequestReference);
-            }, request.Username);
+            }, request);
         }
 
         /// <summary>
@@ -156,7 +156,7 @@
                 var bill = await repository.GetBill(request.BillId);
 
                 return assembler.NewGetBillResponse(bill, request.RequestReference);
-            }, request.Username);
+            }, request);
         }
 
         /// <summary>
@@ -170,7 +170,7 @@
                 var bills = await repository.GetBillsForUser(request.UserId);
 
                 return assembler.NewGetBillsForUserResponse(bills, request.RequestReference);
-            }, request.Username);
+            }, request);
         }
 
         /// <summary>
@@ -188,7 +188,7 @@
                 var data = dataTransformer.GetOutgoingBillsForMonth(request.MonthNumber, bills);
 
                 return assembler.NewGetBillsForUserForMonthResponse(data, request.RequestReference);
-            }, request.Username);
+            }, request);
         }
 
         #endregion

--- a/API/MyMoney.API.Orchestrators/Spending/ExpenditureOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Spending/ExpenditureOrchestrator.cs
@@ -158,21 +158,11 @@
         /// </returns>
         public async Task<GetExpenditureForUserResponse> GetExpenditureForUser(GetExpenditureForUserRequest request)
         {
-            var response = new GetExpenditureForUserResponse();
+            return await Orchestrate(async delegate{
+                var expenditure = await repository.GetExpenditureForUser(request.UserId);
 
-            try
-            {
-                var expenditures = await repository.GetExpenditureForUser(request.UserId);
-
-                response = assembler.NewGetExpenditureForUserResponse(expenditures, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetExpenditureForUser");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetExpenditureForUserResponse(expenditure, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -185,21 +175,11 @@
         public async Task<GetExpenditureForUserForMonthResponse> GetExpenditureForUserForMonth(
             GetExpenditureForUserForMonthRequest request)
         {
-            var response = new GetExpenditureForUserForMonthResponse();
+            return await Orchestrate(async delegate {
+                var expenditure = await repository.GetExpenditureForUserForMonth(request.UserId);
 
-            try
-            {
-                var expenditures = await repository.GetExpenditureForUserForMonth(request.UserId);
-
-                response = assembler.NewGetExpenditureForUserForMonthResponse(expenditures, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetExpenditureForUserForMonth");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetExpenditureForUserForMonthResponse(expenditure, request.RequestReference);
+            }, request);
         }
 
         #endregion

--- a/API/MyMoney.API.Orchestrators/Spending/ExpenditureOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Spending/ExpenditureOrchestrator.cs
@@ -90,24 +90,14 @@
         /// <returns>
         ///     The response object.
         /// </returns>
-        public async Task<AddExpenditureResponse> AddExpenditure(AddExpenditureRequest request, string username)
+        public async Task<AddExpenditureResponse> AddExpenditure(AddExpenditureRequest request)
         {
-            var response = new AddExpenditureResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var dataModel = assembler.NewExpenditureDataModel(request.Expenditure);
                 var newDataModel = await repository.AddExpenditure(dataModel);
 
-                response = assembler.NewAddExpenditureResponse(newDataModel, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, username, GetType(), "AddExpenditure");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewAddExpenditureResponse(newDataModel, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -119,21 +109,11 @@
         /// </returns>
         public async Task<DeleteExpenditureResponse> DeleteExpenditure(DeleteExpenditureRequest request)
         {
-            var response = new DeleteExpenditureResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var deleteSuccess = await repository.DeleteExpenditure(request.ExpenditureId);
 
-                response = assembler.NewDeleteExpenditureResponse(deleteSuccess, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "DeleteExpenditure");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewDeleteExpenditureResponse(deleteSuccess, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -145,22 +125,12 @@
         /// </returns>
         public async Task<EditExpenditureResponse> EditExpenditure(EditExpenditureRequest request)
         {
-            var response = new EditExpenditureResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var dataModel = assembler.NewExpenditureDataModel(request.Expenditure);
                 var newDataModel = await repository.EditExpenditure(dataModel);
 
-                response = assembler.NewEditExpenditureResponse(newDataModel, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "EditExpenditure");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewEditExpenditureResponse(newDataModel, request.RequestReference);
+            }, request);
         }
 
         /// <summary>
@@ -172,21 +142,11 @@
         /// </returns>
         public async Task<GetExpenditureResponse> GetExpenditure(GetExpenditureRequest request)
         {
-            var response = new GetExpenditureResponse();
-
-            try
-            {
+            return await Orchestrate(async delegate {
                 var expenditure = await repository.GetExpenditure(request.ExpenditureId);
 
-                response = assembler.NewGetExpenditureResponse(expenditure, request.RequestReference);
-            }
-            catch (Exception ex)
-            {
-                var err = ErrorHelper.Create(ex, request.Username, GetType(), "GetExpenditure");
-                response.AddError(err);
-            }
-
-            return response;
+                return assembler.NewGetExpenditureResponse(expenditure, request.RequestReference);
+            }, request);
         }
 
         /// <summary>

--- a/API/MyMoney.API.Orchestrators/Spending/Interfaces/IBillOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Spending/Interfaces/IBillOrchestrator.cs
@@ -24,9 +24,8 @@
         ///     Adds a bill.
         /// </summary>
         /// <param name="request">The request.</param>
-        /// <param name="username">The username.</param>
         /// <returns>The response object.</returns>
-        Task<AddBillResponse> AddBill(AddBillRequest request, string username);
+        Task<AddBillResponse> AddBill(AddBillRequest request);
 
         /// <summary>
         ///     Deletes a bill.

--- a/API/MyMoney.API.Orchestrators/Spending/Interfaces/IExpenditureOrchestrator.cs
+++ b/API/MyMoney.API.Orchestrators/Spending/Interfaces/IExpenditureOrchestrator.cs
@@ -22,7 +22,7 @@
         /// <param name="request">The request.</param>
         /// <param name="username">The username.</param>
         /// <returns>The response object.</returns>
-        Task<AddExpenditureResponse> AddExpenditure(AddExpenditureRequest request, string username);
+        Task<AddExpenditureResponse> AddExpenditure(AddExpenditureRequest request);
 
         /// <summary>
         ///     Removes an expenditure from the database.

--- a/API/MyMoney.API/Controllers/Saving/GoalController.cs
+++ b/API/MyMoney.API/Controllers/Saving/GoalController.cs
@@ -66,7 +66,7 @@
         [Route("add")]
         public async Task<IHttpActionResult> AddGoal([FromBody] AddGoalRequest request)
         {
-            var response = await orchestrator.AddGoal(request, request.Username);
+            var response = await orchestrator.AddGoal(request);
 
             return Ok(response);
         }

--- a/API/MyMoney.API/Controllers/Spending/BillController.cs
+++ b/API/MyMoney.API/Controllers/Spending/BillController.cs
@@ -67,7 +67,7 @@
         [Route("add")]
         public async Task<IHttpActionResult> AddBill([FromBody] AddBillRequest request)
         {
-            var response = await orchestrator.AddBill(request, request.Username);
+            var response = await orchestrator.AddBill(request);
 
             return Ok(response);
         }

--- a/API/MyMoney.API/Controllers/Spending/ExpenditureController.cs
+++ b/API/MyMoney.API/Controllers/Spending/ExpenditureController.cs
@@ -67,7 +67,7 @@
         [Route("add")]
         public async Task<IHttpActionResult> AddExpenditure([FromBody] AddExpenditureRequest request)
         {
-            var response = await orchestrator.AddExpenditure(request, request.Username);
+            var response = await orchestrator.AddExpenditure(request);
 
             return Ok(response);
         }


### PR DESCRIPTION
Refactored API orchestrators to use new 'Orchestrate' method in the base class. Cut down on orchestrator method size by a significant amount.